### PR TITLE
Incorrect link to wormhole explorer

### DIFF
--- a/src/reference/usefulLinks.md
+++ b/src/reference/usefulLinks.md
@@ -24,7 +24,7 @@ Tilt is a Kubernetes-based tool that runs a copy of every chain along side a Gua
 
 The Wormhole core repository can be found at [https://github.com/wormhole-foundation/wormhole](https://github.com/wormhole-foundation/wormhole).
 
-### [Wormhole Explorer](https://wormholenetwork.com/en/explorer)
+### [Wormhole Explorer](https://wormholenetwork.com/explorer)
 
 Tool to observe all Wormhole activity and can help you parse VAAs after they've been picked up the Guardian network.
 


### PR DESCRIPTION
The link to the wormhole explorer shows a 404 as it links to `https://wormholenetwork.com/en/explorer`.  The correct link is `https://wormholenetwork.com/explorer`