### PR TITLE
Update 3_coreLayerContracts.md

### DIFF
--- a/src/wormhole/3_coreLayerContracts.md
+++ b/src/wormhole/3_coreLayerContracts.md
@@ -10,7 +10,7 @@ In general, Core Contracts are simple and can be broken down to a **sending** an
 
 Below is the mechanism by which Wormhole messages (aka Verified Action Approval, VAA) are emitted:
 
-    publishMessage(
+    publishMessage()(
         int nonce,
         byte[] payload,
         int consistencyLevel


### PR DESCRIPTION
In the text, there is a mistake in the line 13 that says 'publishMessage' should be 'publishMessage()'. It should include parentheses at the end to indicate that it is a function. The corrected version should be 'publishMessage()'.